### PR TITLE
fix mixing of reset and reboot words

### DIFF
--- a/hostpwrctl.cpp
+++ b/hostpwrctl.cpp
@@ -361,7 +361,7 @@ void showUsage(const char* app)
   on     - turn the host on
   off    - turn the host off
   soft   - gracefully turn the host off
-  reset  - resetting host power
+  reboot - cycle host power
   status - show actual host power state
 )");
 }


### PR DESCRIPTION
This commit fixes mixing of reset and reboot words in the help message.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>